### PR TITLE
PackageManager: Add configuration to specify vendor platform signatures

### DIFF
--- a/core/res/res/values/x_config.xml
+++ b/core/res/res/values/x_config.xml
@@ -143,4 +143,8 @@
     <!-- Whether to send camera status intent -->
     <bool name="config_sendCameraStatusIntent">false</bool>
     
+    <!-- The list of vendor package signatures that should also be considered
+         platform signatures, specifically for use on devices with a vendor partition. -->
+    <string-array name="config_vendorPlatformSignatures">
+    </string-array>
 </resources>

--- a/core/res/res/values/x_symbols.xml
+++ b/core/res/res/values/x_symbols.xml
@@ -190,4 +190,7 @@
   
   <!-- Whether to send camera status intent -->
   <java-symbol type="bool" name="config_sendCameraStatusIntent" />
+  
+  <!-- Vendor signatures -->
+  <java-symbol type="array" name="config_vendorPlatformSignatures" />
 </resources>


### PR DESCRIPTION
Devices with split system/vendor images may want to use the OEM's vendor
image. In that case, the OEM's platform signature is not actually the
same as the platform signature used to sign the Lineage system image.
Allow devices to specify an OEM platform signature which will also be
recognized as the system's platform signature.

* anayw2001 edits - bring up to 11

Change-Id: Ida9bb25a32234af9d9507a214eae6a4672320d2b
(cherry picked from commit 9a3492cd7c8e668e8a531d57404649f4dbd45810)